### PR TITLE
Adds functionality for extracting request headers, changes params for storeMeta & fixes some of the detector functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -701,6 +701,14 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
             "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
+        "axios": {
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "requires": {
+                "follow-redirects": "1.5.10"
+            }
+        },
         "babel-jest": {
             "version": "24.9.0",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.9.0.tgz",
@@ -1610,6 +1618,24 @@
             "dev": true,
             "requires": {
                 "locate-path": "^3.0.0"
+            }
+        },
+        "follow-redirects": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+            "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+            "requires": {
+                "debug": "=3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "for-in": {
@@ -3679,8 +3705,7 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-            "dev": true
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nan": {
             "version": "2.13.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "program": "node dist/app.js"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "dotenv": "^8.2.0",
     "node-fetch": "^2.6.0",
     "twit": "^2.2.11"

--- a/src/data-access-layer/storeMeta.ts
+++ b/src/data-access-layer/storeMeta.ts
@@ -13,11 +13,16 @@ import IHeadersObject from '../interfaces/IHeadersObject'
 import { HTTPMethods } from '../enums/HTTPMethods'
 import { APIs } from '../enums/APIs'
 
+// TODO add param for req headers
+
+// TODO send in request header as string, fix to string[] here
+// to not get it confused with response headers if in wrong order
+
 export const storeResponseMeta = async (
   api: APIs,
   wholeURI: string,
   endpoint: string,
-  statusCode: number,
+  statusCode: number, // TODO this should be object with both status number & status text
   headers: IHeadersObject,
   body: object,
   httpMethod: string

--- a/src/data-access-layer/storeMeta.ts
+++ b/src/data-access-layer/storeMeta.ts
@@ -37,6 +37,7 @@ export const storeResponseMeta = async (resParamsObj: IResonseParams) => {
     statusCode: resParamsObj.status.statusCode,
 
     isBreakingSelfDescriptiveness: isBreakingSelfDescriptiveness(
+      resParamsObj.requestHeaders,
       resParamsObj.responseHeaders,
       nonstandardHeaders
     ),
@@ -51,17 +52,24 @@ export const storeResponseMeta = async (resParamsObj: IResonseParams) => {
 
     isIgnoringCaching: isIgnoringCaching(
       HTTPMethod,
+      resParamsObj.requestHeaders,
       resParamsObj.responseHeaders
     ),
 
-    isIgnoringMIMEType: isIgnoringMIMEType(resParamsObj.responseHeaders),
+    isIgnoringMIMEType: isIgnoringMIMEType(
+      resParamsObj.requestHeaders,
+      resParamsObj.responseHeaders
+    ),
 
     isIgnoringStatusCode: isIgnoringStatusCode(
       HTTPMethod,
       resParamsObj.status.statusCode
     ),
 
-    isMisusingCookies: isMisusingCookies(resParamsObj.responseHeaders),
+    isMisusingCookies: isMisusingCookies(
+      resParamsObj.requestHeaders,
+      resParamsObj.responseHeaders
+    ),
   }
 
   writeToFile(responseMeta)

--- a/src/interfaces/IHeadersObject.ts
+++ b/src/interfaces/IHeadersObject.ts
@@ -1,3 +1,3 @@
 export default interface IHeadersObject {
-  [key: string]: string
+  [key: string]: any
 }

--- a/src/interfaces/IResponseParams.ts
+++ b/src/interfaces/IResponseParams.ts
@@ -14,5 +14,6 @@ export default interface IResonseParams {
 
   requestHeaders: IHeadersObject
   responseHeaders: IHeadersObject
+
   body: object
 }

--- a/src/interfaces/IResponseParams.ts
+++ b/src/interfaces/IResponseParams.ts
@@ -1,0 +1,18 @@
+import { APIs } from '../enums/APIs'
+import IHeadersObject from './IHeadersObject'
+
+export default interface IResonseParams {
+  api: APIs
+  wholeURI: string
+  endpoint: string
+
+  httpMethod: string
+  status: {
+    statusCode: number
+    statusText: string
+  }
+
+  requestHeaders: IHeadersObject
+  responseHeaders: IHeadersObject
+  body: object
+}

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -100,8 +100,6 @@ export const isIgnoringMIMEType = (
   responseHeaders: IHeadersObject
 ): boolean => {
   const acceptedMIMETypes: string[] = getHeaderValue(requestHeaders, 'Accept')
-  // TODO remove console.log, just for debugging now
-  console.log(acceptedMIMETypes)
   const contentType: string = getHeaderValue(responseHeaders, 'Content-Type')
 
   return (

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -20,17 +20,22 @@ import {
 // TODO change these
 
 /**
- * @param headers response headers
+ * @param requestHeaders request headers
+ * @param responseHeaders response headers
  * @param nonstandardHeaders empty string[] for any detected nonstandard headers
  * @returns true if detects Breaking Self-Descriptiveness antipattern
  */
 export const isBreakingSelfDescriptiveness = (
-  headers: IHeadersObject,
+  requestHeaders: IHeadersObject,
+  responseHeaders: IHeadersObject,
   nonstandardHeaders: string[]
 ): boolean => {
-  const responseHeaderKeys: string[] = Object.keys(headers)
+  const headerKeys: string[] = [].concat(
+    Object.keys(requestHeaders),
+    Object.keys(responseHeaders)
+  )
 
-  for (const headerKey of responseHeaderKeys) {
+  for (const headerKey of headerKeys) {
     if (!isStandardHeader(headerKey)) {
       nonstandardHeaders.push(headerKey)
     }

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -28,6 +28,10 @@ export const isBreakingSelfDescriptiveness = (
   responseHeaders: IHeadersObject,
   nonstandardHeaders: string[]
 ): boolean => {
+  // TODO this function needs to be fixed still
+  // ask for list of req headers & res headers
+  // should check separately
+
   const headerKeys: string[] = [].concat(
     Object.keys(requestHeaders),
     Object.keys(responseHeaders)
@@ -121,6 +125,8 @@ export const isIgnoringStatusCode = (
   statusCode: number
 ): boolean => {
   // TODO this function needs to be fixed still
+  // ask for list of appropriate combinations of:
+  // httpMethod, statusCode and statusText
 
   switch (httpMethod) {
     case GET:

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -93,15 +93,22 @@ export const isIgnoringCaching = (
 }
 
 /**
- * @param headers response headers
+ * @param requestHeaders request headers
+ * @param responseHeaders response headers
  * @returns true if detects Ignoring MIME Type antipattern
  */
-export const isIgnoringMIMEType = (headers: IHeadersObject): boolean => {
-  // TODO check accept array, log it
-  // make sure content type is in the accept array
+export const isIgnoringMIMEType = (
+  requestHeaders: IHeadersObject,
+  responseHeaders: IHeadersObject
+): boolean => {
+  const acceptedMIMETypes: string[] = getHeaderValue(requestHeaders, 'Accept')
+  // TODO remove console.log, just for debugging now
+  console.log(acceptedMIMETypes)
+  const contentType: string = getHeaderValue(responseHeaders, 'Content-Type')
 
-  const contentType = getHeaderValue(headers, 'Content-Type')
-  return !contentType || // !std(accept) && !isStandardMIMEType(contentType)  
+  return (
+    !acceptedMIMETypes.includes(contentType) && !isStandardMIMEType(contentType)
+  )
 }
 
 /**
@@ -113,6 +120,8 @@ export const isIgnoringStatusCode = (
   httpMethod: string,
   statusCode: number
 ): boolean => {
+  // TODO this function needs to be fixed still
+
   switch (httpMethod) {
     case GET:
       return !GETStatuses().includes(statusCode)

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -76,18 +76,22 @@ export const isIgnoringCaching = (
 ): boolean => {
   if (httpMethod !== GET) return false
 
-  const headers = [].concat(requestHeaders, responseHeaders)
-
   if (
-    !containsHeaderLowercasedOrCapitalized(headers, 'Etag') ||
-    !containsHeaderLowercasedOrCapitalized(headers, 'Cache-Control')
+    !containsHeaderLowercasedOrCapitalized(responseHeaders, 'Etag') ||
+    !containsHeaderLowercasedOrCapitalized(responseHeaders, 'Cache-Control')
   ) {
     return true
   }
 
-  const caching = getHeaderValue(headers, 'Cache-Control')
+  const clientCaching = getHeaderValue(requestHeaders, 'Cache-Control')
+  const serverCaching = getHeaderValue(responseHeaders, 'Cache-Control')
 
-  return caching === 'no-cache' || caching === 'no-store'
+  return (
+    clientCaching === 'no-cache' ||
+    clientCaching === 'no-store' ||
+    serverCaching === 'no-cache' ||
+    serverCaching === 'no-store'
+  )
 }
 
 /**

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -142,5 +142,8 @@ export const isIgnoringStatusCode = (
  * @param headers response headers
  * @returns true if detects Misusing Cookies antipattern
  */
-export const isMisusingCookies = (headers: IHeadersObject): boolean =>
-  containsCookieHeader(headers)
+export const isMisusingCookies = (
+  requestHeaders: IHeadersObject,
+  responseHeaders: IHeadersObject
+): boolean =>
+  containsCookieHeader(requestHeaders) || containsCookieHeader(responseHeaders)

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -17,8 +17,6 @@ import {
   containsCookieHeader,
 } from './detectorHelpers'
 
-// TODO change these
-
 /**
  * @param requestHeaders request headers
  * @param responseHeaders response headers

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -47,34 +47,38 @@ export const isBreakingSelfDescriptiveness = (
 /**
  * @param body response body
  * @param httpMethod request method
- * @param headers response headers
+ * @param responseHeaders response headers
  * @returns true if detects Forgetting Hypermedia antipattern
  */
 export const isForgettingHypermedia = (
   body: object,
   httpMethod: string,
-  headers: IHeadersObject
+  responseHeaders: IHeadersObject
 ): boolean => {
   const bodyKeys: string[] = getAllKeys(body)
 
   return (
     (httpMethod === GET && !containsLinks(bodyKeys)) ||
     (httpMethod === POST &&
-      !containsHeaderLowercasedOrCapitalized(headers, 'Location') &&
+      !containsHeaderLowercasedOrCapitalized(responseHeaders, 'Location') &&
       !containsLinks(bodyKeys))
   )
 }
 
 /**
  * @param httpMethod request method
- * @param headers response headers
+ * @param requestHeaders request headers
+ * @param responseHeaders response headers
  * @returns true if detects Ignoring Caching antipattern
  */
 export const isIgnoringCaching = (
   httpMethod: string,
-  headers: IHeadersObject
+  requestHeaders: IHeadersObject,
+  responseHeaders: IHeadersObject
 ): boolean => {
   if (httpMethod !== GET) return false
+
+  const headers = [].concat(requestHeaders, responseHeaders)
 
   if (
     !containsHeaderLowercasedOrCapitalized(headers, 'Etag') ||
@@ -93,8 +97,11 @@ export const isIgnoringCaching = (
  * @returns true if detects Ignoring MIME Type antipattern
  */
 export const isIgnoringMIMEType = (headers: IHeadersObject): boolean => {
+  // TODO check accept array, log it
+  // make sure content type is in the accept array
+
   const contentType = getHeaderValue(headers, 'Content-Type')
-  return !contentType || !isStandardMIMEType(contentType)
+  return !contentType || // !std(accept) && !isStandardMIMEType(contentType)  
 }
 
 /**

--- a/src/lib/designAntipatternDetectors.ts
+++ b/src/lib/designAntipatternDetectors.ts
@@ -17,6 +17,8 @@ import {
   containsCookieHeader,
 } from './detectorHelpers'
 
+// TODO change these
+
 /**
  * @param headers response headers
  * @param nonstandardHeaders empty string[] for any detected nonstandard headers

--- a/src/lib/detectorHelpers.ts
+++ b/src/lib/detectorHelpers.ts
@@ -90,5 +90,7 @@ export const getHeaderValue = (
 
   if (!headerValue) return undefined
 
-  return headerValue.toLowerCase()
+  return typeof headerValue === 'string'
+    ? headerValue.toLowerCase()
+    : headerValue
 }

--- a/src/lib/detectorHelpers.ts
+++ b/src/lib/detectorHelpers.ts
@@ -83,7 +83,7 @@ export const containsHeaderLowercasedOrCapitalized = (
 export const getHeaderValue = (
   headers: IHeadersObject,
   capitalizedHeaderName: string
-): string | undefined => {
+): any => {
   const headerValue =
     headers[capitalizedHeaderName] ||
     headers[capitalizedHeaderName.toLowerCase()]

--- a/src/requests/bitly/index.ts
+++ b/src/requests/bitly/index.ts
@@ -39,15 +39,17 @@ export default async () => {
       }
     })
   )
-  result.map((res) =>
-    storeResponseMeta(
-      APIs.bitly,
-      res.wholeURI,
-      res.endpoint,
-      res.statusCode,
-      res.headers,
-      res.body,
-      res.httpMethod
-    )
-  )
+  // TODO argument should now be an object, see: src/interfaces/IResponseParams.ts
+
+  //result.map((res) =>
+  //   storeResponseMeta(
+  //     APIs.bitly,
+  //     res.wholeURI,
+  //     res.endpoint,
+  //     res.statusCode,
+  //      res.headers,
+  //  res.body,
+  //    res.httpMethod
+  // )
+  // )
 }

--- a/src/requests/disqus/index.ts
+++ b/src/requests/disqus/index.ts
@@ -46,16 +46,18 @@ export default async () => {
         }
       })
     )
-    result.map((res) =>
-      storeResponseMeta(
-        APIs.disqus,
-        res.wholeURI,
-        res.endpoint,
-        res.statusCode,
-        res.headers,
-        res.body,
-        res.httpMethod
-      )
-    )
+    // TODO argument should now be an object, see: src/interfaces/IResponseParams.ts
+
+    // result.map((res) =>
+    //   storeResponseMeta(
+    //     APIs.disqus,
+    //     res.wholeURI,
+    //     res.endpoint,
+    //     res.statusCode,
+    //     res.headers,
+    //     res.body,
+    //     res.httpMethod
+    //   )
+    // )
   }
 }

--- a/src/requests/stackExchange/stackExchange.ts
+++ b/src/requests/stackExchange/stackExchange.ts
@@ -1,4 +1,5 @@
 import fetch, { Response } from 'node-fetch'
+import axios from 'axios'
 import { storeResponseMeta } from '../../data-access-layer/storeMeta'
 import { APIs } from '../../enums/APIs'
 import IHeadersObject from '../../interfaces/IHeadersObject'
@@ -8,6 +9,21 @@ export const doStackExchangeRequests = (): void => {
   stackOverflowInfo()
   relatedQuestionsSO()
 }
+
+// TODO use axios instead here, after changing params for storeResMeta
+
+axios
+  .get('https://api.stackexchange.com/2.2/info?site=stackoverflow')
+  .then((response) => {
+    const rawReqHeaders = response.request._header.split('\r\n')
+    rawReqHeaders.shift()
+    const reqHeaders = rawReqHeaders.filter((item) => item !== '')
+
+    console.log(reqHeaders)
+    console.log(response.data)
+    console.log(response.status)
+    console.log(response.statusText)
+  })
 
 async function stackOverflowInfo() {
   const uri = 'https://api.stackexchange.com/2.2/info?site=stackoverflow'

--- a/src/requests/stackExchange/stackExchange.ts
+++ b/src/requests/stackExchange/stackExchange.ts
@@ -1,7 +1,6 @@
 import axios from 'axios'
 import { storeResponseMeta } from '../../data-access-layer/storeMeta'
 import { APIs } from '../../enums/APIs'
-import IHeadersObject from '../../interfaces/IHeadersObject'
 import { GET, POST, PUT, PATCH, DELETE } from '../../utils/HTTPMethods'
 import extractRequestHeaders from '../../utils/extractRequestHeaders'
 
@@ -15,35 +14,25 @@ async function stackOverflowInfo() {
 
   axios.get(uri).then((response) => {
     const reqHeaderString = response.request._header
-    const requestHeaders = extractRequestHeaders(reqHeaderString)
+    const reqHeaders = extractRequestHeaders(reqHeaderString)
 
-    console.log('stackexchange')
-    console.log(uri)
-    console.log('/2.2/info?site=stackoverflow')
+    storeResponseMeta({
+      api: APIs.stackExchange,
+      wholeURI: uri,
+      endpoint: '/2.2/info?site=stackoverflow',
 
-    console.log('GET')
-    console.log({
-      statusCode: response.status,
-      statusText: response.statusText,
+      httpMethod: GET,
+      status: {
+        statusCode: response.status,
+        statusText: response.statusText,
+      },
+
+      requestHeaders: reqHeaders,
+      responseHeaders: response.headers,
+
+      body: response.data,
     })
-
-    console.log(requestHeaders)
-    console.log(response.headers)
-
-    console.log(response.data)
   })
-
-  /*
-  storeResponseMeta(
-    APIs.stackExchange,
-    uri,
-    '/2.2/info?site=stackoverflow',
-    res.status,
-    headers,
-    body,
-    GET
-  )
-  */
 }
 
 /**
@@ -56,52 +45,26 @@ async function relatedQuestionsSO() {
   const uri =
     'https://api.stackexchange.com/2.2/questions/60075228;60075237;57496313/related?order=desc&sort=activity&site=stackoverflow'
 
-  // TODO make req & storeMeta
+  axios.get(uri).then((response) => {
+    const reqHeaderString = response.request._header
+    const reqHeaders = extractRequestHeaders(reqHeaderString)
 
-  // axios.get(uri).then((response) => {
-  //   const reqHeaderString = response.request._header
-  //   const requestHeaders = extractRequestHeaders(reqHeaderString)
+    storeResponseMeta({
+      api: APIs.stackExchange,
+      wholeURI: uri,
+      endpoint:
+        '/2.2/questions/60075228;60075237;57496313/related?order=desc&sort=activity&site=stackoverflow',
 
-  //   console.log('stackexchange')
-  //   console.log(uri)
-  //   console.log('/2.2/info?site=stackoverflow')
+      httpMethod: GET,
+      status: {
+        statusCode: response.status,
+        statusText: response.statusText,
+      },
 
-  //   console.log('GET')
-  //   console.log({
-  //     statusCode: response.status,
-  //     statusText: response.statusText,
-  //   })
+      requestHeaders: reqHeaders,
+      responseHeaders: response.headers,
 
-  //   console.log(requestHeaders)
-  //   console.log(response.headers)
-
-  //   console.log(response.data)
-  // })
-
-  /*
-  storeResponseMeta(
-    APIs.stackExchange,
-    uri,
-    '/2.2/questions/{question_ids}/related?order=desc&sort=activity&site=stackoverflow',
-    res.status,
-    headers,
-    body,
-    GET
-  )
-  */
+      body: response.data,
+    })
+  })
 }
-
-/*
-function getHeaders(res: Response): IHeadersObject {
-  const headers: IHeadersObject = {}
-  const rawHeaders = res.headers.raw()
-  const headerKeys = Object.keys(rawHeaders)
-  const headerValues = Object.values(rawHeaders)
-
-  for (let i = 0; i < headerKeys.length; i++) {
-    headers[headerKeys[i]] = headerValues[i][0]
-  }
-
-  return headers
-}
-*/

--- a/src/requests/stackExchange/stackExchange.ts
+++ b/src/requests/stackExchange/stackExchange.ts
@@ -18,8 +18,8 @@ function stackOverflowInfo() {
 
     storeResponseMeta({
       api: APIs.stackExchange,
-      wholeURI: uri,
       endpoint: '/2.2/info?site=stackoverflow',
+      wholeURI: uri,
 
       httpMethod: GET,
       status: {
@@ -51,9 +51,9 @@ function relatedQuestionsSO() {
 
     storeResponseMeta({
       api: APIs.stackExchange,
-      wholeURI: uri,
       endpoint:
         '/2.2/questions/60075228;60075237;57496313/related?order=desc&sort=activity&site=stackoverflow',
+      wholeURI: uri,
 
       httpMethod: GET,
       status: {

--- a/src/requests/stackExchange/stackExchange.ts
+++ b/src/requests/stackExchange/stackExchange.ts
@@ -9,7 +9,7 @@ export const doStackExchangeRequests = (): void => {
   relatedQuestionsSO()
 }
 
-async function stackOverflowInfo() {
+function stackOverflowInfo() {
   const uri = 'https://api.stackexchange.com/2.2/info?site=stackoverflow'
 
   axios.get(uri).then((response) => {
@@ -41,7 +41,7 @@ async function stackOverflowInfo() {
  * https://stackoverflow.com/questions/60075237/best-way-to-handle-an-account-linking-verification-system
  * https://stackoverflow.com/questions/57496313/execution-failed-for-task-appmergedebugresources-com-android-builder-interna
  */
-async function relatedQuestionsSO() {
+function relatedQuestionsSO() {
   const uri =
     'https://api.stackexchange.com/2.2/questions/60075228;60075237;57496313/related?order=desc&sort=activity&site=stackoverflow'
 

--- a/src/requests/stackExchange/stackExchange.ts
+++ b/src/requests/stackExchange/stackExchange.ts
@@ -4,6 +4,7 @@ import { storeResponseMeta } from '../../data-access-layer/storeMeta'
 import { APIs } from '../../enums/APIs'
 import IHeadersObject from '../../interfaces/IHeadersObject'
 import { GET, POST, PUT, PATCH, DELETE } from '../../utils/HTTPMethods'
+import extractRequestHeaders from '../../utils/extractRequestHeaders'
 
 export const doStackExchangeRequests = (): void => {
   stackOverflowInfo()
@@ -32,6 +33,9 @@ async function stackOverflowInfo() {
   const headers = getHeaders(res)
   const body = JSON.parse(await res.text())
 
+  // TODO log extracted headers
+
+  /*
   storeResponseMeta(
     APIs.stackExchange,
     uri,
@@ -41,6 +45,7 @@ async function stackOverflowInfo() {
     body,
     GET
   )
+  */
 }
 
 /**

--- a/src/requests/stackExchange/stackExchange.ts
+++ b/src/requests/stackExchange/stackExchange.ts
@@ -1,4 +1,3 @@
-import fetch, { Response } from 'node-fetch'
 import axios from 'axios'
 import { storeResponseMeta } from '../../data-access-layer/storeMeta'
 import { APIs } from '../../enums/APIs'
@@ -11,29 +10,28 @@ export const doStackExchangeRequests = (): void => {
   relatedQuestionsSO()
 }
 
-// TODO use axios instead here, after changing params for storeResMeta
-
-axios
-  .get('https://api.stackexchange.com/2.2/info?site=stackoverflow')
-  .then((response) => {
-    const rawReqHeaders = response.request._header.split('\r\n')
-    rawReqHeaders.shift()
-    const reqHeaders = rawReqHeaders.filter((item) => item !== '')
-
-    console.log(reqHeaders)
-    console.log(response.data)
-    console.log(response.status)
-    console.log(response.statusText)
-  })
-
 async function stackOverflowInfo() {
   const uri = 'https://api.stackexchange.com/2.2/info?site=stackoverflow'
 
-  const res = await fetch(uri)
-  const headers = getHeaders(res)
-  const body = JSON.parse(await res.text())
+  axios.get(uri).then((response) => {
+    const reqHeaderString = response.request._header
+    const requestHeaders = extractRequestHeaders(reqHeaderString)
 
-  // TODO log extracted headers
+    console.log('stackexchange')
+    console.log(uri)
+    console.log('/2.2/info?site=stackoverflow')
+
+    console.log('GET')
+    console.log({
+      statusCode: response.status,
+      statusText: response.statusText,
+    })
+
+    console.log(requestHeaders)
+    console.log(response.headers)
+
+    console.log(response.data)
+  })
 
   /*
   storeResponseMeta(
@@ -58,10 +56,29 @@ async function relatedQuestionsSO() {
   const uri =
     'https://api.stackexchange.com/2.2/questions/60075228;60075237;57496313/related?order=desc&sort=activity&site=stackoverflow'
 
-  const res = await fetch(uri)
-  const headers = getHeaders(res)
-  const body = JSON.parse(await res.text())
+  // TODO make req & storeMeta
 
+  // axios.get(uri).then((response) => {
+  //   const reqHeaderString = response.request._header
+  //   const requestHeaders = extractRequestHeaders(reqHeaderString)
+
+  //   console.log('stackexchange')
+  //   console.log(uri)
+  //   console.log('/2.2/info?site=stackoverflow')
+
+  //   console.log('GET')
+  //   console.log({
+  //     statusCode: response.status,
+  //     statusText: response.statusText,
+  //   })
+
+  //   console.log(requestHeaders)
+  //   console.log(response.headers)
+
+  //   console.log(response.data)
+  // })
+
+  /*
   storeResponseMeta(
     APIs.stackExchange,
     uri,
@@ -71,8 +88,10 @@ async function relatedQuestionsSO() {
     body,
     GET
   )
+  */
 }
 
+/*
 function getHeaders(res: Response): IHeadersObject {
   const headers: IHeadersObject = {}
   const rawHeaders = res.headers.raw()
@@ -85,3 +104,4 @@ function getHeaders(res: Response): IHeadersObject {
 
   return headers
 }
+*/

--- a/src/requests/twitter/index.ts
+++ b/src/requests/twitter/index.ts
@@ -31,15 +31,17 @@ export default async () => {
     const preRes: any = await T.post(preTweet[0].url, preTweet[0].params)
     const id_str = preRes.data.id_str
 
-    storeResponseMeta(
-      APIs.twitter,
-      preRes.resp.request.href,
-      preTweet[0].url,
-      preRes.resp.statusCode,
-      preRes.resp.headers,
-      preRes.data,
-      preTweet[0].method
-    )
+    // TODO argument should now be an object, see: src/interfaces/IResponseParams.ts
+
+    // storeResponseMeta(
+    //   APIs.twitter,
+    //   preRes.resp.request.href,
+    //   preTweet[0].url,
+    //   preRes.resp.statusCode,
+    //   preRes.resp.headers,
+    //   preRes.data,
+    //   preTweet[0].method
+    // )
 
     for (const tweet of tweeting) {
       try {

--- a/src/utils/extractRequestHeaders.ts
+++ b/src/utils/extractRequestHeaders.ts
@@ -1,0 +1,7 @@
+export default (reqHeaderText: string): string[] => {
+  const rawReqHeaders = reqHeaderText.split('\r\n')
+  rawReqHeaders.shift()
+
+  const reqHeaders = rawReqHeaders.filter((item) => item !== '')
+  return reqHeaders
+}

--- a/src/utils/extractRequestHeaders.ts
+++ b/src/utils/extractRequestHeaders.ts
@@ -9,11 +9,23 @@ export default (reqHeaderText: string): IHeadersObject => {
 
   reqHeaderFields.forEach((field) => {
     const colonIndex = field.indexOf(':')
+
     const key = field.slice(0, colonIndex)
-    const value = field.slice(colonIndex + 1).replace(' ', '')
+    const value = field.includes(', ')
+      ? getFieldArray(field, colonIndex)
+      : getFieldString(field, colonIndex)
 
     requestHeadersObj[key] = value
   })
 
   return requestHeadersObj
 }
+
+const getFieldArray = (field: string, colonIndex: number): string[] =>
+  field
+    .slice(colonIndex + 1)
+    .replace(' ', '')
+    .split(', ')
+
+const getFieldString = (field: string, colonIndex: number): string =>
+  field.slice(colonIndex + 1).replace(' ', '')

--- a/src/utils/extractRequestHeaders.ts
+++ b/src/utils/extractRequestHeaders.ts
@@ -1,7 +1,19 @@
-export default (reqHeaderText: string): string[] => {
-  const rawReqHeaders = reqHeaderText.split('\r\n')
-  rawReqHeaders.shift()
+import IHeadersObject from '../interfaces/IHeadersObject'
 
-  const reqHeaders = rawReqHeaders.filter((item) => item !== '')
-  return reqHeaders
+export default (reqHeaderText: string): IHeadersObject => {
+  const rawReqHeaderFields = reqHeaderText.split('\r\n')
+  rawReqHeaderFields.shift()
+  const reqHeaderFields = rawReqHeaderFields.filter((item) => item !== '')
+
+  const requestHeadersObj: IHeadersObject = {}
+
+  reqHeaderFields.forEach((field) => {
+    const colonIndex = field.indexOf(':')
+    const key = field.slice(0, colonIndex)
+    const value = field.slice(colonIndex + 1).replace(' ', '')
+
+    requestHeadersObj[key] = value
+  })
+
+  return requestHeadersObj
 }

--- a/test/caching.test.ts
+++ b/test/caching.test.ts
@@ -4,6 +4,8 @@ import { GET, POST, PUT, PATCH, DELETE } from '../src/utils/HTTPMethods'
 // TODO mention full coverage of all branches, statements etc of detector functions in report
 // with image
 
+// TODO 2, most tests are slightly broken now, many require both req & res headers
+
 ///
 
 // FALSE


### PR DESCRIPTION
Nu har storeMeta-funktionen (för att spara info i JSON-filen) bara en parameter, ett objekt med de attribut med värdetyper som anges i interfacet i filen: src/interfaces/IResponseParams.ts

Ett av attributen i objektet är request headers, nu finns en funktion för att extrahera request headers från en sträng i filen: src/utils/extractRequestHeaders.ts

Du kan se hur detta kan gå till i: src/requests/stackExchange/stackExchange.ts

Där används nu axios för anropen. Man behöver kunna få ut request headers från biblioteket som används.

Jag har kommenterat ut kod i twitter, bitly- och disqusmodulerna. Detta för att programmet skulle kunna kompileras och köras. Men dom modulerna behöver ju också kalla på storeMeta funktionen med ett IResponseParams objekt. 

Jag har även fixat flera av detektorfunktionerna, så man skiljer på request och response headers där.

Dock så behöver vi fråga om hur vi ska göra med breaking self descriptiveness och hur vi ska göra med ignoring status code. Vi behöver ha en exhaustive list av request headers och response headers. Vi behöver också en exhaustive list av lämpliga kombinationer av httpMethod, statusCode & statusText.

Flera av testerna är trasiga nu när flera funktioners parametrar har ändrats. Vi får uppdatera testerna när vi fixat detektorfunktionerna. 