### PR TITLE
Own object design antipatterns

### DIFF
--- a/src/data-access-layer/storeMeta.ts
+++ b/src/data-access-layer/storeMeta.ts
@@ -39,6 +39,9 @@ export const storeResponseMeta = async (resParamsObj: IResonseParams) => {
 
     nonstandardHeaders: nonstandardHeaders,
 
+    // empty for now in this program
+    linguisticAntipatterns: {},
+
     designAntipatterns: {
       isBreakingSelfDescriptiveness: isBreakingSelfDescriptiveness(
         resParamsObj.requestHeaders,

--- a/src/data-access-layer/storeMeta.ts
+++ b/src/data-access-layer/storeMeta.ts
@@ -37,40 +37,42 @@ export const storeResponseMeta = async (resParamsObj: IResonseParams) => {
     httpMethod: HTTPMethod,
     statusCode: resParamsObj.status.statusCode,
 
-    isBreakingSelfDescriptiveness: isBreakingSelfDescriptiveness(
-      resParamsObj.requestHeaders,
-      resParamsObj.responseHeaders,
-      nonstandardHeaders
-    ),
-
     nonstandardHeaders: nonstandardHeaders,
 
-    isForgettingHypermedia: isForgettingHypermedia(
-      resParamsObj.body,
-      HTTPMethod,
-      resParamsObj.responseHeaders
-    ),
+    designAntipatterns: {
+      isBreakingSelfDescriptiveness: isBreakingSelfDescriptiveness(
+        resParamsObj.requestHeaders,
+        resParamsObj.responseHeaders,
+        nonstandardHeaders
+      ),
 
-    isIgnoringCaching: isIgnoringCaching(
-      HTTPMethod,
-      resParamsObj.requestHeaders,
-      resParamsObj.responseHeaders
-    ),
+      isForgettingHypermedia: isForgettingHypermedia(
+        resParamsObj.body,
+        HTTPMethod,
+        resParamsObj.responseHeaders
+      ),
 
-    isIgnoringMIMEType: isIgnoringMIMEType(
-      resParamsObj.requestHeaders,
-      resParamsObj.responseHeaders
-    ),
+      isIgnoringCaching: isIgnoringCaching(
+        HTTPMethod,
+        resParamsObj.requestHeaders,
+        resParamsObj.responseHeaders
+      ),
 
-    isIgnoringStatusCode: isIgnoringStatusCode(
-      HTTPMethod,
-      resParamsObj.status.statusCode
-    ),
+      isIgnoringMIMEType: isIgnoringMIMEType(
+        resParamsObj.requestHeaders,
+        resParamsObj.responseHeaders
+      ),
 
-    isMisusingCookies: isMisusingCookies(
-      resParamsObj.requestHeaders,
-      resParamsObj.responseHeaders
-    ),
+      isIgnoringStatusCode: isIgnoringStatusCode(
+        HTTPMethod,
+        resParamsObj.status.statusCode
+      ),
+
+      isMisusingCookies: isMisusingCookies(
+        resParamsObj.requestHeaders,
+        resParamsObj.responseHeaders
+      ),
+    },
   }
 
   writeToFile(responseMeta)

--- a/src/interfaces/IResponseMeta.ts
+++ b/src/interfaces/IResponseMeta.ts
@@ -11,6 +11,10 @@ export default interface IResponseMeta {
 
   nonstandardHeaders: INonStandardHeader[]
 
+  linguisticAntipatterns: {
+    [key: string]: boolean
+  }
+
   designAntipatterns: {
     isBreakingSelfDescriptiveness: boolean
 

--- a/src/interfaces/IResponseMeta.ts
+++ b/src/interfaces/IResponseMeta.ts
@@ -9,17 +9,19 @@ export default interface IResponseMeta {
   httpMethod: string
   statusCode: number
 
-  isBreakingSelfDescriptiveness: boolean
-
   nonstandardHeaders: INonStandardHeader[]
 
-  isForgettingHypermedia: boolean
+  designAntipatterns: {
+    isBreakingSelfDescriptiveness: boolean
 
-  isIgnoringCaching: boolean
+    isForgettingHypermedia: boolean
 
-  isIgnoringMIMEType: boolean
+    isIgnoringCaching: boolean
 
-  isIgnoringStatusCode: boolean
+    isIgnoringMIMEType: boolean
 
-  isMisusingCookies: boolean
+    isIgnoringStatusCode: boolean
+
+    isMisusingCookies: boolean
+  }
 }


### PR DESCRIPTION
Creates objects within each endpoint's object. To store data about design & linguistic antipatterns in. 

Design antipatterns are filled in here in this program.

The linguistic antipatterns object is left empty in this program, will be used in the correlations program. 