### PR TITLE
Fixes MIME Type and status detection bugs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,10 @@ import fs from 'fs'
 
 dotenv.config()
 
+// TODO
+// 1. fix status, patch, only check get/post/put/delete ignore any other http methods
+// 2. investigate mime type
+
 // TODO fix stack exchange
 // import { doStackExchangeRequests } from './requests/stackExchange/stackExchange'
 import doTwitterRequests from './requests/twitter'

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,10 +3,6 @@ import fs from 'fs'
 
 dotenv.config()
 
-// TODO
-// 1. fix status, patch, only check get/post/put/delete ignore any other http methods
-// 2. investigate mime type
-
 // TODO fix stack exchange
 // import { doStackExchangeRequests } from './requests/stackExchange/stackExchange'
 import doTwitterRequests from './requests/twitter'

--- a/src/lib/detectorHelpers.ts
+++ b/src/lib/detectorHelpers.ts
@@ -127,6 +127,13 @@ export const isValidStatusCombo = (
   statusText: string,
   standardStatusCombos: IStatusCombo[]
 ): boolean =>
+  // standard status combos only includes checks for
+  // http methods get, post, put & delete
+  httpMethod !==
+    (HTTPMethods.GET ||
+      HTTPMethods.POST ||
+      HTTPMethods.PUT ||
+      HTTPMethods.DELETE) ||
   standardStatusCombos.filter(
     (combo) =>
       combo.method.includes(httpMethod) &&

--- a/src/lib/detectorHelpers.ts
+++ b/src/lib/detectorHelpers.ts
@@ -64,7 +64,11 @@ export const isAcceptedMIMEType = (
   acceptedMIMETypes: string[]
 ): boolean =>
   // '*/*' means data of any kind is accepted
-  acceptedMIMETypes.includes('*/*') || acceptedMIMETypes.includes(contentType)
+  acceptedMIMETypes.includes('*/*') ||
+  acceptedMIMETypes.includes(trimmedContentType(contentType))
+
+const trimmedContentType = (contentType: string): string =>
+  contentType.split(';')[0]
 
 export const isStandardMIMEType = (contentType: string): boolean =>
   MIMETypes.some((type) => contentType.includes(type))


### PR DESCRIPTION
**MIME Type bug fix**
For the mime type, sometimes the response content type header can look something like this: 
`application/json; charset=8`
Solves bug by splitting content type header by any ; and only checking what's before. 

**Status bug fix**
The xml file with standard combinations only includes combinations for http methods get, post, put & delete.
Solves bug by returning false if the http method is something else, to not get any false positives. 